### PR TITLE
DP-684

### DIFF
--- a/src/Database/Schema/OracleSchema.php
+++ b/src/Database/Schema/OracleSchema.php
@@ -391,7 +391,7 @@ EOD;
         // 2: Checks column DEFAULT for used sequence.NEXTVAL or Trigger-based auto-increment
         $sequenceName = $this->getSequenceNameFromDataDefault($columnRawData) ||
             $this->getSequenceNameFromTrigger($columnSchema, $tableSchema);
-        if ($sequenceName !== null) {
+        if ($sequenceName !== null && !empty($sequenceName)) {
             $columnSchema->autoIncrement = true;
             $tableSchema->sequenceName = $sequenceName;
             return;

--- a/src/Database/Schema/OracleSchema.php
+++ b/src/Database/Schema/OracleSchema.php
@@ -451,7 +451,7 @@ EOD;
                 return $sequenceName;
             }
         }
-        return false;
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Problem
Currently, DreamFactory may fail to return the auto-generated ID when POSTing new records to Oracle tables with auto-incrementing primary keys. This occurs because the existing schema detection logic in `OracleSchema.php` primarily relied on parsing triggers and missed other common auto-increment configurations (e.g., Oracle 12c+ Identity Columns, or sequences explicitly defined in column defaults). This resulted in the `autoIncrement` flag on the column schema not being set correctly, leading to `null` IDs in API responses despite successful record creation.

### Solution
This PR enhances `OracleSchema.php` to more accurately detect auto-incrementing primary key columns in Oracle databases. The new `detectAutoIncrement` method implements a prioritized approach:

1.  **Oracle 12c+ Identity Columns:** Directly checks the `identity_column` attribute from `ALL_TAB_COLUMNS`. This is the most reliable and modern way for Oracle to handle auto-increments.
2.  **Sequence in Column Default:** If not an identity column, it parses the `data_default` column attribute for patterns like `SCHEMA.SEQUENCE_NAME.NEXTVAL` or `SEQUENCE_NAME.NEXTVAL`.
3.  **Trigger-based Auto-increment:** As a fallback, it analyzes `BEFORE EACH ROW` INSERT triggers associated with the table to identify sequence usage for the primary key. This one was already implemented and now simply moved to separate method

By correctly identifying these auto-increment mechanisms, the `ColumnSchema->autoIncrement` property and `TableSchema->sequenceName` (where applicable) are populated more reliably. This provides the necessary metadata for the DreamFactory core to potentially retrieve and return the generated ID after an insert operation, addressing the issue of null IDs in POST responses for Oracle.

### Key Changes
- Introduced the `detectAutoIncrement` private method in `OracleSchema.php`, which orchestrates the new detection logic.
- `detectAutoIncrement` is now called within `loadTableColumns` for primary key columns.
- The SQL query in `loadTableColumns` now fetches the `a.identity_column` to support identity column detection.
- Added helper methods for clarity and modularity:
    - `isIdentityColumn`: Checks the `identity_column` raw data.
    - `getSequenceNameFromDataDefault`: Extracts sequence name from the column's default DDL value.
    - `extractSequenceName`: A regex-based utility to robustly parse sequence names (potentially schema-qualified).
- The existing trigger-based sequence detection has been refactored into `getSequenceNameFromTrigger` and integrated as the third step in the prioritized detection logic.