### PR TITLE
Upgrade to Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-sqldb": "~1.2",
-    "yajra/laravel-oci8":    "^11.0"
+    "php":                   "^8.3",
+    "laravel/helpers":       "^1.8",
+    "dreamfactory/df-sqldb": "~1.4",
+    "yajra/laravel-oci8":    "^13.3"
+  },
+  "require-dev": {
+    "laravel/framework":     "^13.7",
+    "mockery/mockery":       "^1.6",
+    "nunomaduro/collision":  "^8.6",
+    "phpunit/phpunit":       "^11.5.3",
+    "orchestra/testbench":   "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Database/Connectors/OracleConnector.php
+++ b/src/Database/Connectors/OracleConnector.php
@@ -22,7 +22,7 @@ class OracleConnector extends \Yajra\Oci8\Connectors\OracleConnector
     /**
      * @inheritdoc
      */
-    public function createConnection($tns, array $config, array $options)
+    public function createConnection($tns, array $config, array $options): PDO|Oci8
     {
         // add fallback in case driver is not set, will use pdo instead
         if (! in_array($config['driver'], ['oci8', 'pdo-via-oci8', 'oracle'])) {

--- a/src/Database/OracleConnection.php
+++ b/src/Database/OracleConnection.php
@@ -9,12 +9,10 @@ class OracleConnection extends Oci8Connection
 {
     /**
      * Get the default query grammar instance.
-     *
-     * @return \Illuminate\Database\Grammar|\Yajra\Oci8\Query\Grammars\OracleGrammar
      */
-    protected function getDefaultQueryGrammar()
+    protected function getDefaultQueryGrammar(): \Yajra\Oci8\Query\Grammars\OracleGrammar
     {
-        return $this->withTablePrefix(new QueryGrammar());
+        return new QueryGrammar($this);
     }
 
     public function getPdo()

--- a/src/Database/Query/Grammars/OracleGrammar.php
+++ b/src/Database/Query/Grammars/OracleGrammar.php
@@ -14,7 +14,7 @@ class OracleGrammar extends \Yajra\Oci8\Query\Grammars\OracleGrammar
      * @param  string $value
      * @return string
      */
-    protected function wrapValue($value)
+    protected function wrapValue($value): string
     {
         if ($value === '*') {
             return $value;


### PR DESCRIPTION
## Summary

Closes the L13 campaign gap for df-oracledb. Includes composer.json bumps **and** L13 source-invariant fixes (`Grammar(Connection)` constructor, removal of `withTablePrefix()`).

## Changes

### composer.json
- Bump `dreamfactory/df-sqldb` ~1.2 → ~1.4 (catches up version drift + L13).
- Bump `yajra/laravel-oci8` ^11.0 → ^13.3 (L13-compatible major).
- Add `php ^8.3` and `laravel/helpers ^1.8`.
- Add require-dev: framework ^13.7, phpunit ^11.5.3, testbench ^11.0, mockery ^1.6, collision ^8.6.

### Source patches for L13 invariants
- **`OracleConnection::getDefaultQueryGrammar()`** — replaced `withTablePrefix(new QueryGrammar())` with `new QueryGrammar($this)`. L13 removed `Grammar::withTablePrefix()` and made the Grammar constructor require a `Connection` argument. Without this, the first SQL exec under L13 would fatal with `BadMethodCallException`.
- **`OracleConnector::createConnection()`** — added typed return `PDO|Oci8` to match Yajra v13.x parent signature.
- **`OracleGrammar::wrapValue()`** — added typed return `string` for parent-class signature alignment.

## Verification

Stage 1 isolated install + autoload smoke:
- `composer install --ignore-platform-req=ext-oci8` resolves cleanly with L13 path-repo siblings.
- `laravel/framework v13.8.0` + `yajra/laravel-oci8 v13.3.0` installed.
- `yajra/laravel-pdo-via-oci8 v3.7.3` confirmed L13-compatible.
- 8/8 `class_exists()` smoke: ServiceProvider, OracleDb, OracleTable, OracleDbConfig, OracleConnection, OracleConnector, OracleSchema, OracleGrammar.

## Runtime container requirement

**ext-oci8 must be installed** in the runtime container. df-docker-base PR will land Oracle Instant Client 23.8 + `pecl install oci8-3.4.x` alongside the ext-mongodb 1.21+ bump. Without ext-oci8 the `oracle` service type cannot be instantiated.

## Verification gaps (honest)

Not yet exercised:
- Connection to a real Oracle DB (requires ext-oci8 + Oracle Instant Client).
- Schema introspection.
- Stored-procedure execution (df-sqldb security audit covered SQL-injection paths but not Oracle PL/SQL specifics).
- Sequence/identity column handling on Oracle 12c+.

## Merge sequence

Wave 1+ tier. Merge after df-sqldb on develop. Coordinate with df-docker-base PR landing ext-oci8 — without that, the published df-oracledb tag won't be runnable.