### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-sqldb": "~1.2",
-    "yajra/laravel-oci8":    "^11.0"
+    "php":                   "^8.3",
+    "laravel/helpers":       "^1.8",
+    "dreamfactory/df-sqldb": "~1.4",
+    "yajra/laravel-oci8":    "^13.3"
+  },
+  "require-dev": {
+    "laravel/framework":     "^13.7",
+    "mockery/mockery":       "^1.6",
+    "nunomaduro/collision":  "^8.6",
+    "phpunit/phpunit":       "^11.5.3",
+    "orchestra/testbench":   "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Database/Connectors/OracleConnector.php
+++ b/src/Database/Connectors/OracleConnector.php
@@ -22,7 +22,7 @@ class OracleConnector extends \Yajra\Oci8\Connectors\OracleConnector
     /**
      * @inheritdoc
      */
-    public function createConnection($tns, array $config, array $options)
+    public function createConnection($tns, array $config, array $options): PDO|Oci8
     {
         // add fallback in case driver is not set, will use pdo instead
         if (! in_array($config['driver'], ['oci8', 'pdo-via-oci8', 'oracle'])) {

--- a/src/Database/OracleConnection.php
+++ b/src/Database/OracleConnection.php
@@ -9,12 +9,10 @@ class OracleConnection extends Oci8Connection
 {
     /**
      * Get the default query grammar instance.
-     *
-     * @return \Illuminate\Database\Grammar|\Yajra\Oci8\Query\Grammars\OracleGrammar
      */
-    protected function getDefaultQueryGrammar()
+    protected function getDefaultQueryGrammar(): \Yajra\Oci8\Query\Grammars\OracleGrammar
     {
-        return $this->withTablePrefix(new QueryGrammar());
+        return new QueryGrammar($this);
     }
 
     public function getPdo()

--- a/src/Database/Query/Grammars/OracleGrammar.php
+++ b/src/Database/Query/Grammars/OracleGrammar.php
@@ -14,7 +14,7 @@ class OracleGrammar extends \Yajra\Oci8\Query\Grammars\OracleGrammar
      * @param  string $value
      * @return string
      */
-    protected function wrapValue($value)
+    protected function wrapValue($value): string
     {
         if ($value === '*') {
             return $value;

--- a/src/Database/Schema/OracleSchema.php
+++ b/src/Database/Schema/OracleSchema.php
@@ -350,10 +350,13 @@ EOD;
                     $sqlNested = <<<EOD
 SELECT column_name, data_type, data_precision, data_scale, data_length, nullable, data_default
 FROM ALL_NESTED_TABLE_COLS
-WHERE owner = '$nestedTableOwner' and table_name = '$nestedTable'
+WHERE owner = :owner and table_name = :name
 and HIDDEN_COLUMN = 'NO'
 EOD;
-                    $resultNested = $this->connection->select($sqlNested);
+                    $resultNested = $this->connection->select($sqlNested, [
+                        ':owner' => $nestedTableOwner,
+                        ':name'  => $nestedTable,
+                    ]);
                     $nestedColumns = [];
                     foreach ($resultNested as $nestedCol) {
                         $nestedCol = array_change_key_case((array)$nestedCol, CASE_LOWER);
@@ -515,11 +518,14 @@ EOD;
                 $sql = <<<EOD
 SELECT column_name, data_type, data_precision, data_scale, data_length, nullable, data_default
 FROM ALL_NESTED_TABLE_COLS
-WHERE owner = '$nestedTableOwner' and table_name = '$nestedTable'
+WHERE owner = :owner and table_name = :name
 and HIDDEN_COLUMN = 'NO'
 EOD;
 
-                $result = $this->connection->select($sql);
+                $result = $this->connection->select($sql, [
+                    ':owner' => $nestedTableOwner,
+                    ':name'  => $nestedTable,
+                ]);
                 $nestedColumns = [];
                 foreach ($result as $nestedColumn) {
                     $nestedColumn = array_change_key_case((array)$nestedColumn, CASE_LOWER);
@@ -546,9 +552,12 @@ EOD;
      */
     protected function getTableConstraints($schema = '')
     {
-        if (is_array($schema)) {
-            $schema = implode("','", $schema);
+        $schemas = is_array($schema) ? array_values($schema) : [$schema];
+        $schemas = array_values(array_filter($schemas, fn ($s) => $s !== '' && $s !== null));
+        if (empty($schemas)) {
+            return [];
         }
+        $placeholders = implode(',', array_fill(0, count($schemas), '?'));
 
         $sql = <<<SQL
 		SELECT A.constraint_type, A.constraint_name, A.owner as table_schema, A.table_name as table_name, B.column_name as column_name,
@@ -557,10 +566,10 @@ EOD;
         left join ALL_CONS_COLUMNS B on B.OWNER = A.OWNER and B.constraint_name = A.constraint_name
         left join ALL_CONSTRAINTS C on C.OWNER = A.r_OWNER and C.constraint_name = A.r_constraint_name
         left join ALL_CONS_COLUMNS D on D.OWNER = C.OWNER and D.constraint_name = C.constraint_name and D.position = B.position
-        WHERE A.OWNER in ('{$schema}')
+        WHERE A.OWNER in ({$placeholders})
 SQL;
 
-        $results = $this->connection->select($sql);
+        $results = $this->connection->select($sql, $schemas);
         $constraints = [];
         foreach ($results as $row) {
             $row = array_change_key_case((array)$row, CASE_LOWER);
@@ -605,12 +614,13 @@ SQL;
         $sql = <<<EOD
 SELECT table_name, owner as table_schema FROM all_tables WHERE nested = 'NO'
 EOD;
-
+        $bindings = [];
         if (!empty($schema)) {
-            $sql .= " AND owner = '$schema'";
+            $sql .= " AND owner = :schema";
+            $bindings[':schema'] = $schema;
         }
 
-        $rows = $this->connection->select($sql);
+        $rows = $this->connection->select($sql, $bindings);
 
         $names = [];
         foreach ($rows as $row) {
@@ -635,12 +645,13 @@ EOD;
         $sql = <<<EOD
 SELECT object_name as table_name, owner as table_schema FROM all_objects WHERE object_type = 'VIEW'
 EOD;
-
+        $bindings = [];
         if (!empty($schema)) {
-            $sql .= " AND owner = '$schema'";
+            $sql .= " AND owner = :schema";
+            $bindings[':schema'] = $schema;
         }
 
-        $rows = $this->connection->select($sql);
+        $rows = $this->connection->select($sql, $bindings);
 
         $names = [];
         foreach ($rows as $row) {
@@ -789,10 +800,21 @@ MYSQL;
         $columns = (array)$columns;
 
         if (!empty($columns)) {
-            if (1 === count($columns)) {
-                return $this->connection->statement("ALTER TABLE $table DROP COLUMN " . $columns[0]);
+            // Quote each identifier — callers historically passed raw user-
+            // supplied column names. Skip if already wrapped in Oracle's
+            // double-quote identifier delimiter.
+            $quotedTable = (str_starts_with(ltrim((string) $table), '"'))
+                ? $table
+                : $this->quoteTableName($table);
+            $quotedCols = array_map(function ($c) {
+                return (str_starts_with(ltrim((string) $c), '"'))
+                    ? (string) $c
+                    : $this->quoteColumnName((string) $c);
+            }, $columns);
+            if (1 === count($quotedCols)) {
+                return $this->connection->statement("ALTER TABLE {$quotedTable} DROP COLUMN " . $quotedCols[0]);
             } else {
-                return $this->connection->statement("ALTER TABLE $table DROP (" . implode(',', $columns) . ")");
+                return $this->connection->statement("ALTER TABLE {$quotedTable} DROP (" . implode(', ', $quotedCols) . ")");
             }
         }
 

--- a/tests/Security/OracleSchemaHardeningTest.php
+++ b/tests/Security/OracleSchemaHardeningTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DreamFactory\Core\OracleDb\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: OracleSchema must parameterize schema/owner lookups + quote
+ * identifiers in DDL helpers.
+ *
+ * Phase 2 audit found 5 SQL interpolation sites + DDL identifier issues:
+ *   - getTableConstraints (A.OWNER IN)
+ *   - getTableNames (owner = '\$schema')
+ *   - getViewNames (owner = '\$schema')
+ *   - loadTableColumns nested-table lookup (owner / table_name)
+ *   - dropColumns ALTER TABLE — identifiers concatenated raw
+ */
+class OracleSchemaHardeningTest extends TestCase
+{
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $sourcePath = __DIR__ . '/../../src/Database/Schema/OracleSchema.php';
+        $this->assertFileExists($sourcePath);
+        $this->contents = file_get_contents($sourcePath);
+    }
+
+    public function testNoOwnerInterpolation(): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            "/owner\s*=\s*'\\\$schema'/i",
+            $this->contents,
+            'No owner = \$schema interpolation must remain'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            "/OWNER in\s*\(\s*'\{\\\$schema\}'\s*\)/",
+            $this->contents,
+            'No OWNER IN (\$schema) interpolation must remain'
+        );
+    }
+
+    public function testNoNestedTableInterpolation(): void
+    {
+        $this->assertDoesNotMatchRegularExpression(
+            "/owner\s*=\s*'\\\$nestedTableOwner'/",
+            $this->contents,
+            'Nested-table lookup must not interpolate \$nestedTableOwner raw'
+        );
+    }
+
+    public function testNamedBindingsUsed(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/:schema\b/',
+            $this->contents,
+            ':schema named placeholder must appear'
+        );
+    }
+
+    public function testDropColumnsQuotesIdentifiers(): void
+    {
+        $start = strpos($this->contents, 'function dropColumns');
+        $this->assertNotFalse($start);
+        $next = strpos($this->contents, "\n    /**", $start + 10);
+        $body = substr($this->contents, $start, $next === false ? null : ($next - $start));
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/ALTER TABLE \$table DROP COLUMN /',
+            $body,
+            'dropColumns must not interpolate raw \$table'
+        );
+        $this->assertMatchesRegularExpression(
+            '/quoteColumnName\b/',
+            $body,
+            'dropColumns must quote column identifiers'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master (NOTE: master ahead of develop)

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

> ⚠️ `master` has commits not in `develop` — listed below. GitHub will
> create a merge commit; both histories are preserved. Reviewer:
> verify the divergent master commits aren't logically conflicting
> with the develop work before merging.

### Verification

The develop HEAD here is the SHA locked into the L13/PHP 8.5 test
bundle. **Full end-to-end smoke passed 2026-05-26** (PHP 8.5.5,
Laravel 13.11.2, df:setup, login, CRUD, OpenAPI gen).

### Coordinated release PRs

One of ~26 coordinated release PRs. Merge order:
foundation → connectors → auth → services → AI → admin UI → host app.
