### PR TITLE
fix: widen yajra/laravel-oci8 to ^11|^12|^13 (df-commercial 7.6.0 blocker)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name":        "dreamfactory/df-oracledb",
+  "name": "dreamfactory/df-oracledb",
   "description": "The DreamFactory(tm) Oracle DB Service.",
-  "keywords":    [
+  "keywords": [
     "dreamfactory",
     "api",
     "rest",
@@ -10,45 +10,45 @@
     "database",
     "db"
   ],
-  "homepage":    "https://www.dreamfactory.com/",
-  "license":     "proprietary",
-  "authors":     [
+  "homepage": "https://www.dreamfactory.com/",
+  "license": "proprietary",
+  "authors": [
     {
-      "name":  "Arif Islam",
+      "name": "Arif Islam",
       "email": "arifislam@dreamfactory.com"
     },
     {
-      "name":  "Lee Hicks",
+      "name": "Lee Hicks",
       "email": "leehicks@dreamfactory.com"
     }
   ],
-  "support":     {
-    "email":  "dspsupport@dreamfactory.com",
+  "support": {
+    "email": "dspsupport@dreamfactory.com",
     "source": "https://github.com/dreamfactorysoftware/df-oracledb",
     "issues": "https://github.com/dreamfactorysoftware/df-oracledb/issues",
-    "wiki":   "https://wiki.dreamfactory.com"
+    "wiki": "https://wiki.dreamfactory.com"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
-  "require":     {
-    "php":                   "^8.3",
-    "laravel/helpers":       "^1.8",
+  "require": {
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
     "dreamfactory/df-sqldb": "~1.4",
-    "yajra/laravel-oci8":    "^13.3"
+    "yajra/laravel-oci8": "^11.0 || ^12.0 || ^13.0"
   },
   "require-dev": {
-    "laravel/framework":     "^13.7",
-    "mockery/mockery":       "^1.6",
-    "nunomaduro/collision":  "^8.6",
-    "phpunit/phpunit":       "^11.5.3",
-    "orchestra/testbench":   "^11.0"
+    "laravel/framework": "^11.15 || ^12.0 || ^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^7.0 || ^8.6",
+    "phpunit/phpunit": "^10.5 || ^11.5.3",
+    "orchestra/testbench": "^9.0 || ^10.0 || ^11.0"
   },
-  "autoload":    {
+  "autoload": {
     "psr-4": {
       "DreamFactory\\Core\\Oracle\\": "src/"
     }
   },
-  "extra":       {
+  "extra": {
     "branch-alias": {
       "dev-develop": "0.15.x-dev"
     },


### PR DESCRIPTION
## Widen yajra/laravel-oci8 constraint for L11/L12/L13 compatibility

### Why
Tag `0.20.1` jumped `yajra/laravel-oci8` from `^11.0` to `^13.3` — Laravel 13 only. That breaks df-commercial's 7.6.0 release (`laravel/framework ^11.15`):

```
yajra/laravel-oci8 v13.3+ requires illuminate/pagination ^13
laravel/framework ^11.15 replaces illuminate/pagination
=> can't coexist => composer.lock regeneration fails
```

`df-commercial` PR [#85](https://github.com/dreamfactorysoftware/df-commercial/pull/85) currently works around this by pinning df-oracledb to `~0.20.0`, but that throws away whatever 0.20.1 added.

### The fix
Widen the runtime constraint so composer picks the right yajra major for the host's Laravel:

| Host Laravel | Selected yajra | illuminate constraint |
|---|---|---|
| ^11.15 | v11.6.7 | `^11.15.0` ✓ |
| ^12.0 | v12.11.0 | `^12` ✓ |
| ^13.0 | v13.5.1 | `^13` ✓ |

```diff
-    "yajra/laravel-oci8": "^13.3"
+    "yajra/laravel-oci8": "^11.0 || ^12.0 || ^13.0"
```

`require-dev` widened in the same direction (`laravel/framework`, `orchestra/testbench`, `phpunit/phpunit`, `nunomaduro/collision`) so contributors can `composer install --dev` against any of L11/L12/L13.

### Other diff noise
JSON pretty-printer normalized the original double-space column alignment to single-space. No semantic change.

### Tag-cut request
Please cut **0.20.2** after this merges so df-commercial PR #85 can flip its constraint from `~0.20.0` (temporary) to `~0.20.2`.

### Test plan
- [ ] `composer install` in a Laravel 11 host with `dreamfactory/df-oracledb: dev-fix/yajra-widen-laravel-compat` resolves cleanly
- [ ] Existing Oracle CRUD smoke still passes against yajra v11.x (it was the runtime before 0.20.1 anyway)
- [ ] CI green
